### PR TITLE
Make localizedComponents available on macOS

### DIFF
--- a/Sources/FredKit/FredKitTimeInterval.swift
+++ b/Sources/FredKit/FredKitTimeInterval.swift
@@ -49,6 +49,7 @@ public extension TimeInterval {
             return LocalizedValue(value: "\(fullAmountOfTimeIntervalOption)", unit: representedTimeInterval.localizedUnitForTimeInterval)
         }
     }
+#endif
     
     var localizedComponents: [LocalizedValue] {
         
@@ -73,7 +74,6 @@ public extension TimeInterval {
         
         return localizedComponents
     }
-#endif
     
     var humanReadableTimeIntervalMaximumDays: String {
         if self < TimeInterval.hour {

--- a/Sources/FredKit/Localized Formatting/LocalizedUnitConverter.swift
+++ b/Sources/FredKit/Localized Formatting/LocalizedUnitConverter.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-#if !os(macOS)
-import UIKit
+import SwiftUI
+
 
 public struct LocalizedValue: Equatable, Hashable, Codable {
 
@@ -20,13 +20,14 @@ public struct LocalizedValue: Equatable, Hashable, Codable {
     public var value: String
     public var unit: String
     
-    public func attributedString(ofSize fontSize: Double, weight: UIFont.Weight) -> NSAttributedString {
+    public func attributedString(ofSize fontSize: Double, weight: Font.Weight) -> AttributedString {
         return StringUnitFormatter.formattedString(fromString: value, fontSize: fontSize, unit: unit, fontWeight: weight)
     }
 }
 
 
-
+#if !os(macOS)
+import UIKit
 public enum UnitSystem: String, Equatable, Hashable, Codable {
     case metric, imperial
 }

--- a/Sources/FredKit/Localized Formatting/StringUnitFormatter.swift
+++ b/Sources/FredKit/Localized Formatting/StringUnitFormatter.swift
@@ -6,36 +6,36 @@
 //  Copyright © 2018 Frederik Riedel. All rights reserved.
 //
 
-#if !os(macOS)
 import Foundation
-import UIKit
+import SwiftUI
 
 public struct StringUnitFormatter {
 
-    private static func font(withSize size: Double, weight: UIFont.Weight) -> UIFont {
-        return UIFont.systemFont(ofSize: CGFloat(size), weight: weight).rounded
+    private static func font(withSize size: Double, weight: Font.Weight) -> Font {
+        return .system(size: size, weight: weight, design: .rounded)
     }
-    
-    public static func formattedString(fromString string: String, fontSize: Double, unit: String, fontWeight: UIFont.Weight, unitColor: UIColor?) -> NSAttributedString {
-        let attributedString = NSMutableAttributedString()
-        
-        attributedString.append(NSAttributedString(string: string, attributes: [.font: font(withSize: fontSize, weight: fontWeight)] ))
-        
-        if let color = unitColor {
-            attributedString.append(NSAttributedString(string: unit.uppercased(), attributes: [.font: font(withSize: 0.8*fontSize, weight: fontWeight), .foregroundColor : color] ))
-        } else {
-            attributedString.append(NSAttributedString(string: unit.uppercased(), attributes: [.font: font(withSize: 0.8*fontSize, weight: fontWeight)] ))
+
+    public static func formattedString(fromString string: String, fontSize: Double, unit: String, fontWeight: Font.Weight, unitColor: Color?) -> AttributedString {
+        var attributedString = AttributedString(string)
+        attributedString.font = font(withSize: fontSize, weight: fontWeight)
+
+        var unitString = AttributedString(unit.uppercased())
+        unitString.font = font(withSize: 0.8 * fontSize, weight: fontWeight)
+
+        if let unitColor {
+            unitString.foregroundColor = unitColor
         }
-        
-        return NSAttributedString(attributedString: attributedString)
+
+        attributedString.append(unitString)
+
+        return attributedString
     }
-    
-    public static func formattedString(fromString string: String, fontSize: Double, unit: String) -> NSAttributedString {
+
+    public static func formattedString(fromString string: String, fontSize: Double, unit: String) -> AttributedString {
         return formattedString(fromString: string, fontSize: fontSize, unit: unit, fontWeight: .regular, unitColor: nil)
     }
-    
-    public static func formattedString(fromString string: String, fontSize: Double, unit: String, fontWeight: UIFont.Weight) -> NSAttributedString {
+
+    public static func formattedString(fromString string: String, fontSize: Double, unit: String, fontWeight: Font.Weight) -> AttributedString {
         return formattedString(fromString: string, fontSize: fontSize, unit: unit, fontWeight: fontWeight, unitColor: nil)
     }
 }
-#endif


### PR DESCRIPTION
As far as I can tell, functions like StringUnitFormatter.formattedString are also used internally on iOS, so changing their signature would be a breaking change. Is it fine to enforce this change, or should I keep full backward compatibility?